### PR TITLE
Queries task

### DIFF
--- a/src/main/java/ja/workshops/hibernate/parts/connectors/H2Connector.java
+++ b/src/main/java/ja/workshops/hibernate/parts/connectors/H2Connector.java
@@ -11,6 +11,17 @@ import java.util.Properties;
  * @author krzysztof.niedzielski
  */
 public class H2Connector extends SessionConnector {
+
+    private String ddlAuto;
+
+    public H2Connector(String ddlAuto) {
+        this.ddlAuto = ddlAuto;
+    }
+
+    public H2Connector() {
+        ddlAuto="create-drop";
+    }
+
     @Override
     Properties loadConnectorSettings() {
         Properties settings = new Properties();
@@ -20,7 +31,7 @@ public class H2Connector extends SessionConnector {
         settings.put(Environment.PASS, "{password}");
         settings.put(Environment.DIALECT, "org.hibernate.dialect.H2Dialect");
         settings.put(Environment.SHOW_SQL, "true");
-        settings.put(Environment.HBM2DDL_AUTO, "create-drop");
+        settings.put(Environment.HBM2DDL_AUTO, ddlAuto);
         settings.put(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread");
         return settings;
     }

--- a/src/main/java/ja/workshops/hibernate/parts/queries/App.java
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/App.java
@@ -1,0 +1,45 @@
+package ja.workshops.hibernate.parts.queries;
+
+
+import ja.workshops.hibernate.parts.connectors.ConnectorManager;
+import ja.workshops.hibernate.parts.connectors.H2Connector;
+import ja.workshops.hibernate.parts.connectors.SessionConnector;
+import ja.workshops.hibernate.parts.connectors.SessionInitializationException;
+import ja.workshops.hibernate.parts.crud.CrudMethods;
+import ja.workshops.hibernate.parts.model.Author;
+import ja.workshops.hibernate.parts.model.Book;
+import ja.workshops.hibernate.parts.model.Genre;
+import org.hibernate.Session;
+
+import java.util.Set;
+
+/**
+ * @author Kamil Rojek
+ */
+public class App {
+    public static void main(String[] args) throws SessionInitializationException {
+        Author author = new Author("Kamil", "R");
+        Set<Author> authors = Set.of(new Author("Jan", "Brzechwa"), new Author("OLA", "POD"));
+        Book book = new Book("BOOK", authors, Genre.CLASSIC);
+
+        connect(new H2Connector())
+                .openCrudSession(new CrudMethods())
+                .updateRecord(author)
+                .updateRecord(authors)
+                .updateRecord(book)
+                .commitAndClose();
+
+        //TODO : You should implement methods listAll and listAllAuthorsWithSpecifiedName in all classes in package ja.workshop.hibernate.query
+        // You can achieve this in several ways.
+        // In this package there are several classes that need implementation.
+        // Names of this classes are not random, they correspond to the way you should implement each class.
+        // All test should pass.
+
+        Session session = connect(new H2Connector("update")).getSession();
+
+    }
+
+    private static ConnectorManager connect(SessionConnector connector) {
+        return ConnectorManager.connect(connector);
+    }
+}

--- a/src/main/java/ja/workshops/hibernate/parts/queries/query/CriteriaApi.java
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/query/CriteriaApi.java
@@ -1,0 +1,28 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.model.Author;
+import org.hibernate.Session;
+
+import java.util.List;
+
+/**
+ * Documentation :
+ * - CriteriaBuilder: https://docs.oracle.com/javaee/7/api/javax/persistence/criteria/CriteriaBuilder.html
+ * - Root : https://docs.oracle.com/javaee/7/api/javax/persistence/criteria/Root.html
+ * - CriteriaQuery: https://docs.oracle.com/javaee/7/api/javax/persistence/criteria/CriteriaQuery.html
+ * - TypedQuery : https://docs.oracle.com/javaee/7/api/javax/persistence/TypedQuery.html
+ * @author krzysztof.niedzielski
+ */
+public class CriteriaApi implements IQuery {
+    @Override
+    public <T> List<T> listAll(Session session, Class T ){
+        // TODO: Implement me!
+       return null;
+    }
+
+    @Override
+    public List<Author> listAllAuthorsWithSpecifiedName(Session session, String name) {
+        // TODO: Implement me!
+        return null;
+    }
+}

--- a/src/main/java/ja/workshops/hibernate/parts/queries/query/HQLQuery.java
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/query/HQLQuery.java
@@ -1,0 +1,27 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.model.Author;
+import org.hibernate.Session;
+
+import java.util.List;
+
+/**
+ * Documentation:
+ * Session : https://docs.jboss.org/hibernate/orm/5.4/javadocs/
+ * Tip: createQuery()
+ * @author krzysztof.niedzielski
+ */
+public class HQLQuery implements  IQuery {
+
+    @Override
+    public <T> List<T> listAll(Session session, Class T ){
+        // TODO: Implement me!
+        return null;
+    }
+
+    @Override
+    public List<Author> listAllAuthorsWithSpecifiedName(Session session, String name) {
+        // TODO: Implement me!
+        return null;
+    }
+}

--- a/src/main/java/ja/workshops/hibernate/parts/queries/query/IQuery.java
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/query/IQuery.java
@@ -1,0 +1,15 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.model.Author;
+import org.hibernate.Session;
+
+import java.util.List;
+
+/**
+ * @author krzysztof.niedzielski
+ */
+public interface IQuery {
+     <T> List<T> listAll(Session session, Class T);
+
+     List<Author> listAllAuthorsWithSpecifiedName(Session session, String name);
+}

--- a/src/main/java/ja/workshops/hibernate/parts/queries/query/NamedQuery.java
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/query/NamedQuery.java
@@ -1,0 +1,26 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.model.Author;
+import org.hibernate.Session;
+
+import java.util.List;
+
+/**
+ * Documentation:
+ * Session : https://docs.jboss.org/hibernate/orm/5.4/javadocs/
+ * Tip: createNamedQuery()
+ * @author krzysztof.niedzielski
+ */
+public class NamedQuery implements IQuery {
+    @Override
+    public <T> List<T> listAll(Session session, Class T ){
+        // TODO: Implement me!
+        return null;
+    }
+
+    @Override
+    public List<Author> listAllAuthorsWithSpecifiedName(Session session, String name) {
+        // TODO: Implement me!
+        return null;
+    }
+}

--- a/src/main/java/ja/workshops/hibernate/parts/queries/query/SQLQuery.java
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/query/SQLQuery.java
@@ -1,0 +1,27 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.model.Author;
+import org.hibernate.Session;
+
+import java.util.List;
+
+/**
+ * Documentation:
+ * Session : https://docs.jboss.org/hibernate/orm/5.4/javadocs/
+ * Tip: createSqlQuery()
+ * createSqlQuery returns List<Object[]> so we have to parse Object[] to Author object.
+ * @author krzysztof.niedzielski
+ */
+public class SQLQuery {
+
+    public List<Author> listAll(Session session) {
+        // TODO: Implement me!
+        return null;
+    }
+
+    public List<Author> listAllAuthorsWithSpecifiedName(Session session, String name) {
+        // TODO: Implement me!
+        return null;
+    }
+
+}

--- a/src/main/java/ja/workshops/hibernate/parts/queries/readme.adoc
+++ b/src/main/java/ja/workshops/hibernate/parts/queries/readme.adoc
@@ -1,0 +1,19 @@
+== Queries
+
+Implement query methods in 4 classes:
+
+1. CriteriaApi
+2. HQLQuery
+3. NamedQuery
+4. SQLQuery
+
+*More information in App class.*
+
+== How to check if implementation is correct
+
+1. Start H2 database server
+2. Check connection credentials in H2Connector class, especially: url, username and password
+3. Run tests
+4. All test passed == you finished  :muscle:
+
+**Now go to App class and read TODO section**

--- a/src/test/java/ja/workshops/hibernate/parts/queries/query/CriteriaApiTest.java
+++ b/src/test/java/ja/workshops/hibernate/parts/queries/query/CriteriaApiTest.java
@@ -1,0 +1,54 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+
+import ja.workshops.hibernate.parts.connectors.ConnectorManager;
+import ja.workshops.hibernate.parts.connectors.H2Connector;
+import ja.workshops.hibernate.parts.connectors.SessionInitializationException;
+import ja.workshops.hibernate.parts.crud.CrudMethods;
+import ja.workshops.hibernate.parts.model.Author;
+import ja.workshops.hibernate.parts.model.Book;
+import ja.workshops.hibernate.parts.model.Genre;
+import org.hibernate.Session;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * @author krzysztof.niedzielski
+ */
+public class CriteriaApiTest {
+
+    private Session session;
+    private IQuery iQuery;
+
+    @BeforeClass
+    public void before() throws SessionInitializationException {
+        Set<Author> authors = Set.of(new Author("Jan", "Brzechwa"), new Author("Julian", "Tuwim"),new Author("Kamil","Rojek"));
+        Book book = new Book("BOOK", authors, Genre.CLASSIC);
+        ConnectorManager.connect(new H2Connector())
+                .openCrudSession(new CrudMethods())
+                .updateRecord(authors)
+                .updateRecord(book)
+                .commitAndClose();
+        this.session = ConnectorManager.connect(new H2Connector("update")).getSession();
+        iQuery= new CriteriaApi();
+    }
+
+    @Test(priority = 0)
+    public void testListAll() {
+        List<Author> list = iQuery.listAll(this.session, Author.class);
+        assertEquals( list.size(),3);
+    }
+
+    @Test(priority = 1)
+    public void testListAllAuthorsWithSpecifiedName() {
+        List<Author> list = iQuery.listAllAuthorsWithSpecifiedName(this.session,"Kamil");
+        assertEquals( list.size(),1);
+        session.close();
+    }
+}

--- a/src/test/java/ja/workshops/hibernate/parts/queries/query/HQLQueryTest.java
+++ b/src/test/java/ja/workshops/hibernate/parts/queries/query/HQLQueryTest.java
@@ -1,0 +1,53 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.connectors.ConnectorManager;
+import ja.workshops.hibernate.parts.connectors.H2Connector;
+import ja.workshops.hibernate.parts.connectors.SessionInitializationException;
+import ja.workshops.hibernate.parts.crud.CrudMethods;
+import ja.workshops.hibernate.parts.model.Author;
+import ja.workshops.hibernate.parts.model.Book;
+import ja.workshops.hibernate.parts.model.Genre;
+import org.hibernate.Session;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author krzysztof.niedzielski
+ */
+public class HQLQueryTest {
+
+
+    private Session session;
+    private IQuery iQuery;
+
+    @BeforeClass
+    public void before() throws SessionInitializationException {
+        Set<Author> authors = Set.of(new Author("Jan", "Brzechwa"), new Author("Julian", "Tuwim"),new Author("Kamil","Rojek"));
+        Book book = new Book("BOOK", authors, Genre.CLASSIC);
+        ConnectorManager.connect(new H2Connector())
+                .openCrudSession(new CrudMethods())
+                .updateRecord(authors)
+                .updateRecord(book)
+                .commitAndClose();
+        this.session = ConnectorManager.connect(new H2Connector("update")).getSession();
+        iQuery= new HQLQuery();
+    }
+
+    @Test(priority = 2)
+    public void testListAll() {
+        List<Author> list = iQuery.listAll(this.session, Author.class);
+        assertEquals( list.size(),3);
+    }
+
+    @Test(priority = 3)
+    public void testListAllAuthorsWithSpecifiedName() {
+        List<Author> list = iQuery.listAllAuthorsWithSpecifiedName(this.session,"Kamil");
+        assertEquals( list.size(),1);
+        session.close();
+    }
+}

--- a/src/test/java/ja/workshops/hibernate/parts/queries/query/NamedQueryTest.java
+++ b/src/test/java/ja/workshops/hibernate/parts/queries/query/NamedQueryTest.java
@@ -1,0 +1,52 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.connectors.ConnectorManager;
+import ja.workshops.hibernate.parts.connectors.H2Connector;
+import ja.workshops.hibernate.parts.connectors.SessionInitializationException;
+import ja.workshops.hibernate.parts.crud.CrudMethods;
+import ja.workshops.hibernate.parts.model.Author;
+import ja.workshops.hibernate.parts.model.Book;
+import ja.workshops.hibernate.parts.model.Genre;
+import org.hibernate.Session;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author krzysztof.niedzielski
+ */
+public class NamedQueryTest {
+    private Session session;
+    private IQuery iQuery;
+
+    @BeforeClass
+    public void before() throws SessionInitializationException {
+        Set<Author> authors = Set.of(new Author("Jan", "Brzechwa"), new Author("Julian", "Tuwim"),new Author("Kamil","Rojek"));
+        Book book = new Book("BOOK", authors, Genre.CLASSIC);
+        ConnectorManager.connect(new H2Connector())
+                .openCrudSession(new CrudMethods())
+                .updateRecord(authors)
+                .updateRecord(book)
+                .commitAndClose();
+        this.session = ConnectorManager.connect(new H2Connector("update")).getSession();
+        iQuery= new NamedQuery();
+    }
+
+    @Test(priority = 4)
+    public void testListAll() {
+        List<Author> list = iQuery.listAll(this.session, Author.class);
+        assertEquals( list.size(),3);
+    }
+
+    @Test(priority = 5)
+    public void testListAllAuthorsWithSpecifiedName() {
+        List<Author> list = iQuery.listAllAuthorsWithSpecifiedName(this.session,"Kamil");
+        assertEquals( list.size(),1);
+        session.close();
+    }
+
+}

--- a/src/test/java/ja/workshops/hibernate/parts/queries/query/SQLQueryTest.java
+++ b/src/test/java/ja/workshops/hibernate/parts/queries/query/SQLQueryTest.java
@@ -1,0 +1,53 @@
+package ja.workshops.hibernate.parts.queries.query;
+
+import ja.workshops.hibernate.parts.connectors.ConnectorManager;
+import ja.workshops.hibernate.parts.connectors.H2Connector;
+import ja.workshops.hibernate.parts.connectors.SessionInitializationException;
+import ja.workshops.hibernate.parts.crud.CrudMethods;
+import ja.workshops.hibernate.parts.model.Author;
+import ja.workshops.hibernate.parts.model.Book;
+import ja.workshops.hibernate.parts.model.Genre;
+import org.hibernate.Session;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author krzysztof.niedzielski
+ */
+public class SQLQueryTest {
+    private Session session;
+    private SQLQuery iQuery;
+
+    @BeforeClass
+    public void before() throws SessionInitializationException {
+        Set<Author> authors = Set.of(new Author("Jan", "Brzechwa"), new Author("Julian", "Tuwim"),new Author("Kamil","Rojek"));
+        Book book = new Book("BOOK", authors, Genre.CLASSIC);
+        ConnectorManager.connect(new H2Connector())
+                .openCrudSession(new CrudMethods())
+                .updateRecord(authors)
+                .updateRecord(book)
+                .commitAndClose();
+        this.session = ConnectorManager.connect(new H2Connector("update")).getSession();
+        iQuery= new SQLQuery();
+    }
+
+    @Test(priority = 6)
+    public void testListAll() {
+        List<Author> list = iQuery.listAll(this.session);
+        assertEquals( list.size(),3);
+    }
+
+    @Test(priority = 7)
+    public void testListAllAuthorsWithSpecifiedName() {
+        List<Author> list = iQuery.listAllAuthorsWithSpecifiedName(this.session,"Kamil");
+        assertEquals( list.size(),1);
+        session.getTransaction().commit();
+        session.close();
+    }
+
+}


### PR DESCRIPTION
Zadanie pokazujące różne sposoby na wysyłanie zapytań do bazy danych poprzez obiekt sesji


`SessionFactory.getSession()`

W paczce ***query*** znajdują się 4 klasy:
1. CriteriaApi
2. HQLQuery
3. NamedQuery
4. SQLQuery

W każdej klasie znajdują się 2 metody:
1. listAll
2. listAllAuthorsWithSpecifiedName

Do każdej z tych klas dostarczone są proste zestawy testowe, więc po implementacji istnieje mozliwosc szybkiej weryfikacji wyników. W kazdej z klas znajdują się odnośniki do dokumentacji oraz metody na które warto zwrócić uwagę w kontekscie danego sposobu generowania kwerend. 

Osoba która przerobi ćwiczenie potrafi:
1. Wymienić 4 sposoby na tworzenie kwerend używając Hibernate
2. Zaimplementować proste kwerendy wybierające

